### PR TITLE
Api/comment cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 
 node_modules
+uploads

--- a/api/src/controllers/tokens.go
+++ b/api/src/controllers/tokens.go
@@ -21,8 +21,6 @@ func CreateToken(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
 	}
 
-	fmt.Println(input)
-
 	user, err := models.FindUserByEmail(input.Email)
 	if err != nil {
 		SendInternalError(ctx, err)

--- a/api/src/controllers/users.go
+++ b/api/src/controllers/users.go
@@ -17,31 +17,39 @@ import (
 )
 
 func CreateUser(ctx *gin.Context) {
+
+	// ============================= Get the request body =========================================
 	var newUser models.User
 	err := ctx.BindJSON(&newUser)
-
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
 		return
 	}
 
+	// ============================= Check if the request body is valid ===========================
 	if newUser.Email == "" || newUser.Password == "" {
 		ctx.JSON(http.StatusBadRequest, gin.H{"message": "Must supply username and password"})
 		return
 	}
 
+	// ============================= Save the user to the database ================================
 	_, err = newUser.Save()
 	if err != nil {
 		SendInternalError(ctx, err)
 		return
 	}
 
+	// =========================== Send a success message to the frontend =========================
+	// No need to send a token as the user is not logged in yet
 	ctx.JSON(http.StatusCreated, gin.H{"message": "OK"})
 }
 
 func UpdateUser(ctx *gin.Context) {
-	// Get user ID
+
+	// ======================= Get the user ID from the context ====================================
 	userIDStr, exists := ctx.Get("userID")
+
+	// Check if userID exists in the context
 	if !exists {
 		ctx.JSON(http.StatusUnauthorized, gin.H{"message": "Unauthorized"})
 		return
@@ -53,27 +61,29 @@ func UpdateUser(ctx *gin.Context) {
 		return
 	}
 
-	// Safely convert to string
+	// ========================== Convert the userID to a string ==================================
+	// This is because the userID is stored as an interface type in the context (I think)
 	userIDString, ok := userIDStr.(string)
 	if !ok {
 		ctx.JSON(http.StatusUnauthorized, gin.H{"message": "Invalid user ID format"})
 		return
 	}
 
+	// ===================== Convert the userID to a uint (for the DB) ============================
 	userID, err := strconv.ParseUint(userIDString, 10, 64)
 	if err != nil {
 		SendInternalError(ctx, err)
 		return
 	}
 
-	// Parse request body
+	// =================== Get the request body (of the things to update) =========================
 	var updates map[string]interface{}
 	if err := ctx.BindJSON(&updates); err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
 		return
 	}
 
-	// Handle profile picture if it exists in the updates
+	// ============================= Handle profile picture if it exists ==========================
 	if profilePictureData, exists := updates["profilePicture"]; exists && profilePictureData != nil {
 		// Convert to string and check if it's a base64 data URI
 		profilePictureStr, ok := profilePictureData.(string)
@@ -93,44 +103,46 @@ func UpdateUser(ctx *gin.Context) {
 		}
 	}
 
-	// 'Push/commit' all these updates to the user in the database
+	// ============================= Update the user in the database ==============================
 	_, err = models.UpdateUser(uint(userID), updates)
 	if err != nil {
 		SendInternalError(ctx, err)
 		return
 	}
 
-	// Generate a new token for the user
+	// ============================= Generate a new token for the user ============================
 	val, _ := ctx.Get("userID")
 	tokenUserID := val.(string)
 	token, _ := auth.GenerateToken(tokenUserID)
 
-	// Send a success message to the frontend
+	// ===================== Send a success message to the frontend (with token) ==================
 	ctx.JSON(http.StatusCreated, gin.H{"message": "User updated successfully", "token": token})
 }
+
 
 // the below helper function handles saves the base64 image (which is sent as a string
 // from the frontend) to the api/uploads directory (so that we can store a path in the DB)
 func saveProfilePicture(base64Image string, userID uint) (string, error) {
-	// Create uploads directory if it already doesn't exist
+
+	// ================== Create the uploads directory (if it doesn't exist) ======================
 	uploadDir := "uploads/profile_pictures"
 	if err := os.MkdirAll(uploadDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create upload directory: %w", err)
 	}
 
-	// Split the base64 string to get the data part
+	// ========================= Split the base64 string to get the data part =========================
 	// apparently the first half is metadata and the second half is the actual image data
-	// we want
+	// we want the second half
 	parts := strings.Split(base64Image, ",")
 	if len(parts) != 2 {
 		return "", fmt.Errorf("invalid base64 image format")
 	}
 
-	// Get the image format from the data URI
+	// ========================= Get the image format from the data URI =============================
 	metadata := parts[0]
 	imageData := parts[1]
 
-	// Determine the extension of the image
+	// ========================= Determine the extension of the image ==============================
 	var extension string
 	if strings.Contains(metadata, "image/jpeg") || strings.Contains(metadata, "image/jpg") {
 		extension = "jpg"
@@ -139,10 +151,10 @@ func saveProfilePicture(base64Image string, userID uint) (string, error) {
 	} else if strings.Contains(metadata, "image/gif") {
 		extension = "gif"
 	} else {
-		extension = "jpg" // we default to jpg if the extension is not found
+		extension = "jpg"
 	}
 
-	// Finally decode the base64 image data
+	// =========== Finally decode the base64 image data (using encoding/base64 package) ===========
 	decoded, err := base64.StdEncoding.DecodeString(imageData)
 	if err != nil {
 		return "", fmt.Errorf("failed to decode base64 image: %w", err)
@@ -153,11 +165,11 @@ func saveProfilePicture(base64Image string, userID uint) (string, error) {
 	filename := fmt.Sprintf("profile_%d_%d.%s", userID, timestamp, extension)
 	fullPath := filepath.Join(uploadDir, filename)
 
-	// Save the file
+	// ============================= Save the file to the uploads directory =======================
 	if err := ioutil.WriteFile(fullPath, decoded, 0644); err != nil {
 		return "", fmt.Errorf("failed to write image file: %w", err)
 	}
 
-	// Return the URL path that will be used to access the image
+	// ================ Return the URL path that will be used to access the image =================
 	return "/uploads/profile_pictures/" + filename, nil
 }

--- a/api/src/models/post.go
+++ b/api/src/models/post.go
@@ -1,19 +1,17 @@
 package models
 
 import (
-	"fmt"
-
 	"gorm.io/gorm"
 )
 
 type Post struct {
 	gorm.Model
-	UserID    uint      `json:"user_id"`
-	User      User      `json:"user"`
-	Question  string    `json:"question"`
-	Answer    string    `json:"answer"`
-	Comments  []Comment `json:"comments"`
-	Likes     []Like    `json:"likes"`
+	UserID   uint      `json:"user_id"`
+	User     User      `json:"user"`
+	Question string    `json:"question"`
+	Answer   string    `json:"answer"`
+	Comments []Comment `json:"comments"`
+	Likes    []Like    `json:"likes"`
 }
 
 func (post *Post) Save() (*Post, error) {
@@ -28,8 +26,6 @@ func (post *Post) Save() (*Post, error) {
 func FetchAllPosts() (*[]Post, error) {
 	var posts []Post
 	err := Database.Find(&posts).Error
-
-	fmt.Println(posts)
 
 	if err != nil {
 		return &[]Post{}, err


### PR DESCRIPTION
Just a bit of housecleaning to make some of the backend code easier to read/understand

- Add uploads/ folder to .gitignore to avoid images being saved on github
- Remove debug print statements from tokens.go & post.go that were bloating the console
- Clean up comments / structure in users.go (no code changed)