### PR TITLE
Api/comment like unlike

### DIFF
--- a/api/src/models/like.go
+++ b/api/src/models/like.go
@@ -27,4 +27,20 @@ func FetchLikesByPostID(postID uint) (*[]Like, error) {
 		return &[]Like{}, err
 	}
 	return &likes, nil
+}
+
+// This is used to check if a user has already liked a post
+// It returns the like if it exists, otherwise it returns nil
+// This helps give us the like/unlike functionality on the frontend
+func FindLikeByUserIDAndPostID(userID uint, postID uint) (*Like, error) {
+	var like Like
+	err := Database.Where("user_id = ? AND post_id = ?", userID, postID).First(&like).Error
+	if err != nil {
+		return nil, err 
+	}
+	return &like, nil
+}
+
+func (like *Like) Delete() error {
+	return Database.Delete(like).Error
 } 

--- a/api/src/models/like.go
+++ b/api/src/models/like.go
@@ -29,7 +29,7 @@ func FetchLikesByPostID(postID uint) (*[]Like, error) {
 	return &likes, nil
 }
 
-// This is used to check if a user has already liked a post
+// This below is used to check if a user has already liked a post
 // It returns the like if it exists, otherwise it returns nil
 // This helps give us the like/unlike functionality on the frontend
 func FindLikeByUserIDAndPostID(userID uint, postID uint) (*Like, error) {

--- a/docs/api_routes/POST_likes.md
+++ b/docs/api_routes/POST_likes.md
@@ -1,0 +1,83 @@
+# POST /likes
+
+This endpoint allows users to like or unlike a post, implementing a toggle functionality.
+
+## Request
+
+### URL
+```
+POST /likes
+```
+
+### Required Headers
+```
+Authorization: "bearer {JWT token}"
+Content-Type: "application/json"
+```
+
+### Request Body
+```json
+{
+  "post_id": 1
+}
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| post_id   | uint | The ID of the post to like/unlike |
+
+## Response
+
+Please not that the response is different (201 and 200) depending on if the like was created or removed. I'm not sure if they is helpful for the frontend for keeping track of state?
+
+### Success Response - Like Created (201 Created)
+Returns a JSON object with a success message and a new JWT token when a like is created.
+
+```json
+{
+  "message": "Like created",
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+### Success Response - Like Removed (200 OK)
+Returns a JSON object with a success message and a new JWT token when a like is removed.
+
+```json
+{
+  "message": "Like removed",
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+### Error Responses
+
+- **400 Bad Request**: If the request body is invalid or missing required fields
+  ```json
+  {
+    "message": "Invalid request body"
+  }
+  ```
+
+- **401 Unauthorized**: If the JWT token is missing or invalid
+  ```json
+  {
+    "message": "Unauthorized"
+  }
+  ```
+
+- **500 Internal Server Error**: If there's a server-side error
+  ```json
+  {
+    "err": "Something went wrong"
+  }
+  ```
+
+## Notes
+- This endpoint requires authentication via a JWT token (as shown in the required headers section)
+- The endpoint implements a toggle functionality:
+  - If the user has not liked the post before, it creates a new like
+  - If the user has already liked the post, it removes the existing like
+      - This is technically done by GORM by just adding a date/time into the 'deleted_at' column in the database. But it's all the same. Any further requests to `GET /likes/post/:post_id` won't include these 'removed' rows.
+- The behavior is determined automatically based on the current state in the database
+- A new JWT token is returned with each successful response for token refresh purposes 


### PR DESCRIPTION
I've changed the `POST /likes` endpoint so that it now not only 'adds' a like (row) to the `like` table in the DB, but it now also 'deletes' that like from the table too.

Basically it allows users to like a post if they haven't already, or remove their like if they have.

- Added `FindLikeByUserIDAndPostID` method to the `Like` model which can be used to check if a like already exists.
- Added `Delete` method to the `Like` model to remove a like.
    - It's worth noting that this 'deleting' is technically done by GORM by just adding a date/time into the 'deleted_at' column in the database. But it's all the same. Any further requests to `GET /likes/post/:post_id` won't include these 'removed' rows.
- Modified the `CreateLike` function in the `likes` controller to:
    - Check if a like exists for the given user and post.
    - If it exists, delete the like (unlike).
    - If it doesn't exist, create a new like.
- Created docs for the endpoint too for reference.