### PR TITLE
No more "record not found" error message when reseeding db

### DIFF
--- a/api/src/seeds/seedfunctions.go
+++ b/api/src/seeds/seedfunctions.go
@@ -1,7 +1,6 @@
 package seeds
 
 import (
-	"github.com/makersacademy/go-react-acebook-template/api/src/models"
 	"gorm.io/gorm"
 )
 
@@ -17,35 +16,15 @@ func DropTablesifExist(db *gorm.DB) {
 	// This function executes raw SQL to drop all tables before reseeding
 
 	// likes table
-	var like models.Comment
-	check_likes := db.First(&like)
-
-	if check_likes.Error == nil {
-		db.Exec("DROP TABLE likes")
-	}
-
+	db.Exec("DROP TABLE IF EXISTS likes")
+	
 	// comments table
-	var comment models.Comment
-	check_comments := db.First(&comment)
-
-	if check_comments.Error == nil {
-		db.Exec("DROP TABLE comments")
-	}
-
+	db.Exec("DROP TABLE IF EXISTS comments")
+	
 	// posts table
-	var post models.Post
-	check_posts := db.First(&post)
-
-	if check_posts.Error == nil {
-		db.Exec("DROP TABLE posts CASCADE")
-	}
-
+	db.Exec("DROP TABLE IF EXISTS posts CASCADE")
+	
 	//users table
-	var user models.User
-	check_users := db.First(&user)
-
-	if check_users.Error == nil {
-		db.Exec("DROP TABLE users CASCADE")
-	}
-
+	db.Exec("DROP TABLE IF EXISTS users CASCADE")
+	
 }


### PR DESCRIPTION
Altered the function that drops the tables so that they just execute raw SQL and check if tables exist this way. (Previously this function worked out if a table existed by trying to grab the first item in that table which was what caused all those error messages in the terminal)