### PR TITLE
question & answer fields can't be blank when updating

### DIFF
--- a/api/src/controllers/posts.go
+++ b/api/src/controllers/posts.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -487,6 +488,21 @@ func UpdatePost(ctx *gin.Context) {
 	if err := ctx.BindJSON(&updates); err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
 		return
+	}
+
+	// ============================= Validate question and answer are not blank ==============================
+	if question, exists := updates["question"]; exists {
+		if questionStr, ok := question.(string); ok && len(strings.TrimSpace(questionStr)) == 0 {
+			ctx.JSON(http.StatusBadRequest, gin.H{"message": "Question cannot be blank"})
+			return
+		}
+	}
+
+	if answer, exists := updates["answer"]; exists {
+		if answerStr, ok := answer.(string); ok && len(strings.TrimSpace(answerStr)) == 0 {
+			ctx.JSON(http.StatusBadRequest, gin.H{"message": "Answer cannot be blank"})
+			return
+		}
 	}
 
 	// ============================= Update the post in the database ==============================

--- a/docs/api_routes/posts/PUT_posts_id.md
+++ b/docs/api_routes/posts/PUT_posts_id.md
@@ -29,7 +29,9 @@ The request body should be a JSON object containing the fields to be updated. Fo
 }
 ```
 
-The above is just an example. Either of the above fields in the post can be included/excluded in the request (i.e. you don't have to incude both)
+The above is just an example. Either of the above fields in the post can be included/excluded in the request (i.e. you don't have to include both).
+
+**Note:** Blank values are not allowed for `question` and `answer` fields. If either field is included in the request, it must contain non-blank content.
 
 ## Response
 
@@ -45,7 +47,7 @@ Returns a JSON object with a success message and a new JWT token.
 
 ### Error Responses
 
-- **400 Bad Request**: If the request body is invalid or the post ID is invalid
+- **400 Bad Request**: If the request body is invalid, the post ID is invalid, or if `question` or `answer` fields are blank
   ```json
   {
     "message": "Invalid request body"
@@ -55,6 +57,18 @@ Returns a JSON object with a success message and a new JWT token.
   ```json
   {
     "message": "Invalid post ID"
+  }
+  ```
+  or
+  ```json
+  {
+    "message": "Question cannot be blank"
+  }
+  ```
+  or
+  ```json
+  {
+    "message": "Answer cannot be blank"
   }
   ```
 
@@ -90,4 +104,5 @@ Returns a JSON object with a success message and a new JWT token.
 - This endpoint requires authentication via JWT token
 - Only the owner of the post can update it
 - Only the fields provided in the request body will be updated
+- Blank values are not allowed for `question` and `answer` fields
 - A new JWT token is returned with each successful response for token refresh purposes 


### PR DESCRIPTION
Sending a PUT request to `/comments/:id` like this:
```json
{
    "question": "",
    "answer": "my answer"
}
```

will now result in a response like this:
```json
 {
    "message": "Question cannot be blank"
  }
```

Also a similar response for a request with a blank `answer` value.