### PR TITLE
Hide messy debug comments when running "go run main.go"

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -16,6 +16,9 @@ func main() {
 	// Load environment variables
 	env.LoadEnv()
 
+	// Set Gin to release mode to hide messy/unhelpful debug logs when running "go run main.go"
+	gin.SetMode(gin.ReleaseMode) // Comment this out to see debug logs
+
 	// Setup the application
 	app := setupApp()
 


### PR DESCRIPTION
I just added a single line of code in `main.go` which hides all of gin's messy/unhelpful debug comments that appear when running `go run main.go`. This line can be commented out to turn them back on.


Running `go run main.go` before:

<img width="1370" alt="Screenshot 2025-04-10 at 13 35 33" src="https://github.com/user-attachments/assets/cc3b0ace-7923-4fa8-bbcf-e24502565157" />

Running `go run main.go` after:

<img width="810" alt="Screenshot 2025-04-10 at 13 36 12" src="https://github.com/user-attachments/assets/f1721aba-5aaa-4f0b-8e46-80ae203e6de5" />

